### PR TITLE
Add GuiBase and GuiObject abstractions and clean up types

### DIFF
--- a/src/engine/widgets/GuiBase.ts
+++ b/src/engine/widgets/GuiBase.ts
@@ -1,0 +1,23 @@
+import { Inst } from "./Instance";
+
+export abstract class GuiBase extends Inst implements GuiBase {
+    protected _absolutePosition: Vector2 = { X: 0, Y: 0 };
+    protected _absoluteRotation = 0;
+    protected _absoluteSize: Vector2 = { X: 0, Y: 0 };
+
+    protected constructor(name: string, className: string, parent?: Instance) {
+        super(name, className, parent);
+    }
+
+    public get AbsolutePosition(): Vector2 {
+        return this._absolutePosition;
+    }
+
+    public get AbsoluteRotation(): number {
+        return this._absoluteRotation;
+    }
+
+    public get AbsoluteSize(): Vector2 {
+        return this._absoluteSize;
+    }
+}

--- a/src/engine/widgets/GuiObject.ts
+++ b/src/engine/widgets/GuiObject.ts
@@ -1,0 +1,268 @@
+import { Event } from "../core/Event";
+import { GuiBase } from "./GuiBase";
+
+export abstract class GuiObject extends GuiBase implements GuiObject {
+    // properties
+    private _anchorPoint: Vector2 = { X: 0, Y: 0 };
+    private _automaticSize: AutomaticSize = "None";
+    private _backgroundColor3: Color3 = { R: 1, G: 1, B: 1 };
+    private _backgroundTransparency = 0;
+    private _borderColor3: Color3 = { R: 0, G: 0, B: 0 };
+    private _borderMode: BorderMode = "Outline";
+    private _borderSizePixel = 1;
+    private _clipsDescendants = false;
+    private _draggable = false;
+    private _layoutOrder = 0;
+    private _position: UDim2 = { X: { Scale: 0, Pixel: 0 }, Y: { Scale: 0, Pixel: 0 } };
+    private _rotation = 0;
+    private _selectable = false;
+    private _selectionImageObject: GuiObject | undefined = undefined;
+    private _selectionOrder = 0;
+    private _size: UDim2 = { X: { Scale: 0, Pixel: 0 }, Y: { Scale: 0, Pixel: 0 } };
+    private _sizeConstraint: SizeConstraint = "RelativeXY";
+    private _transparency = 0;
+    private _visible = true;
+    private _zIndex = 0;
+
+    // events
+    public readonly DragBegin = new Event<{ initialPosition: UDim2 }>();
+    public readonly DragStopped = new Event<{ x: number; y: number }>();
+    public readonly InputBegan = new Event<{ input: InputObject }>();
+    public readonly InputChanged = new Event<{ input: InputObject }>();
+    public readonly InputEnded = new Event<{ input: InputObject }>();
+    public readonly MouseEnter = new Event<{ x: number; y: number }>();
+    public readonly MouseLeave = new Event<{ x: number; y: number }>();
+    public readonly MouseMoved = new Event<{ x: number; y: number }>();
+    public readonly MouseWheelBackward = new Event<{ x: number; y: number }>();
+    public readonly MouseWheelForward = new Event<{ x: number; y: number }>();
+    public readonly SelectionGained = new Event<void>();
+    public readonly SelectionLost = new Event<void>();
+    public readonly TouchLongPress = new Event<{ touchPositions: Array<Vector2>; state: UserInputState }>();
+    public readonly TouchPan = new Event<{
+        touchPositions: Array<Vector2>;
+        totalTranslation: Vector2;
+        velocity: Vector2;
+        state: UserInputState;
+    }>();
+    public readonly TouchPinch = new Event<{
+        touchPositions: Array<Vector2>;
+        scale: number;
+        velocity: number;
+        state: UserInputState;
+    }>();
+    public readonly TouchRotate = new Event<{
+        touchPositions: Array<Vector2>;
+        rotation: number;
+        velocity: number;
+        state: UserInputState;
+    }>();
+    public readonly TouchSwipe = new Event<{ swipeDirection: SwipeDirection; numberOfTouches: number }>();
+    public readonly TouchTap = new Event<{ touchPositions: Array<Vector2> }>();
+
+    protected constructor(name: string, className: string, parent?: Instance) {
+        super(name, className, parent);
+    }
+
+    // property accessors
+    public get AnchorPoint(): Vector2 {
+        return this._anchorPoint;
+    }
+    public set AnchorPoint(v: Vector2) {
+        this._anchorPoint = v;
+        this.signalPropertyChanged("AnchorPoint");
+    }
+
+    public get AutomaticSize(): AutomaticSize {
+        return this._automaticSize;
+    }
+    public set AutomaticSize(v: AutomaticSize) {
+        this._automaticSize = v;
+        this.signalPropertyChanged("AutomaticSize");
+    }
+
+    public get BackgroundColor3(): Color3 {
+        return this._backgroundColor3;
+    }
+    public set BackgroundColor3(v: Color3) {
+        this._backgroundColor3 = v;
+        this.signalPropertyChanged("BackgroundColor3");
+    }
+
+    public get BackgroundTransparency(): number {
+        return this._backgroundTransparency;
+    }
+    public set BackgroundTransparency(v: number) {
+        this._backgroundTransparency = v;
+        this.signalPropertyChanged("BackgroundTransparency");
+    }
+
+    public get BorderColor3(): Color3 {
+        return this._borderColor3;
+    }
+    public set BorderColor3(v: Color3) {
+        this._borderColor3 = v;
+        this.signalPropertyChanged("BorderColor3");
+    }
+
+    public get BorderMode(): BorderMode {
+        return this._borderMode;
+    }
+    public set BorderMode(v: BorderMode) {
+        this._borderMode = v;
+        this.signalPropertyChanged("BorderMode");
+    }
+
+    public get BorderSizePixel(): number {
+        return this._borderSizePixel;
+    }
+    public set BorderSizePixel(v: number) {
+        this._borderSizePixel = v;
+        this.signalPropertyChanged("BorderSizePixel");
+    }
+
+    public get ClipsDescendants(): boolean {
+        return this._clipsDescendants;
+    }
+    public set ClipsDescendants(v: boolean) {
+        this._clipsDescendants = v;
+        this.signalPropertyChanged("ClipsDescendants");
+    }
+
+    public get Draggable(): boolean {
+        return this._draggable;
+    }
+    public set Draggable(v: boolean) {
+        this._draggable = v;
+        this.signalPropertyChanged("Draggable");
+    }
+
+    public get LayoutOrder(): number {
+        return this._layoutOrder;
+    }
+    public set LayoutOrder(v: number) {
+        this._layoutOrder = v;
+        this.signalPropertyChanged("LayoutOrder");
+    }
+
+    public get Position(): UDim2 {
+        return this._position;
+    }
+    public set Position(v: UDim2) {
+        this._position = v;
+        this.signalPropertyChanged("Position");
+    }
+
+    public get Rotation(): number {
+        return this._rotation;
+    }
+    public set Rotation(v: number) {
+        this._rotation = v;
+        this.signalPropertyChanged("Rotation");
+    }
+
+    public get Selectable(): boolean {
+        return this._selectable;
+    }
+    public set Selectable(v: boolean) {
+        this._selectable = v;
+        this.signalPropertyChanged("Selectable");
+    }
+
+    public get SelectionImageObject(): GuiObject | undefined {
+        return this._selectionImageObject;
+    }
+    public set SelectionImageObject(v: GuiObject | undefined) {
+        this._selectionImageObject = v;
+        this.signalPropertyChanged("SelectionImageObject");
+    }
+
+    public get SelectionOrder(): number {
+        return this._selectionOrder;
+    }
+    public set SelectionOrder(v: number) {
+        this._selectionOrder = v;
+        this.signalPropertyChanged("SelectionOrder");
+    }
+
+    public get Size(): UDim2 {
+        return this._size;
+    }
+    public set Size(v: UDim2) {
+        this._size = v;
+        this.signalPropertyChanged("Size");
+    }
+
+    public get SizeConstraint(): SizeConstraint {
+        return this._sizeConstraint;
+    }
+    public set SizeConstraint(v: SizeConstraint) {
+        this._sizeConstraint = v;
+        this.signalPropertyChanged("SizeConstraint");
+    }
+
+    public get Transparency(): number {
+        return this._transparency;
+    }
+    public set Transparency(v: number) {
+        this._transparency = v;
+        this.signalPropertyChanged("Transparency");
+    }
+
+    public get Visible(): boolean {
+        return this._visible;
+    }
+    public set Visible(v: boolean) {
+        this._visible = v;
+        this.signalPropertyChanged("Visible");
+    }
+
+    public get ZIndex(): number {
+        return this._zIndex;
+    }
+    public set ZIndex(v: number) {
+        this._zIndex = v;
+        this.signalPropertyChanged("ZIndex");
+    }
+
+    // tween methods (simple implementation)
+    public TweenPosition(
+        endPosition: UDim2,
+        easingDirection?: EasingDirection,
+        easingStyle?: EasingStyle,
+        time = 0,
+        override = true,
+        callback?: (finishedTween: TweenStatus) => void,
+    ): boolean {
+        this.Position = endPosition;
+        if (callback) callback("Completed");
+        return true;
+    }
+
+    public TweenSize(
+        endSize: UDim2,
+        easingDirection?: EasingDirection,
+        easingStyle?: EasingStyle,
+        time = 0,
+        override = true,
+        callback?: (finishedTween: TweenStatus) => void,
+    ): boolean {
+        this.Size = endSize;
+        if (callback) callback("Completed");
+        return true;
+    }
+
+    public TweenSizeAndPosition(
+        endSize: UDim2,
+        endPosition: UDim2,
+        easingDirection?: EasingDirection,
+        easingStyle?: EasingStyle,
+        time = 0,
+        override = true,
+        callback?: (finishedTween: TweenStatus) => void,
+    ): boolean {
+        this.Size = endSize;
+        this.Position = endPosition;
+        if (callback) callback("Completed");
+        return true;
+    }
+}

--- a/src/engine/widgets/types.d.ts
+++ b/src/engine/widgets/types.d.ts
@@ -23,9 +23,29 @@ interface UDim2 {
 }
 
 interface Vector2 {
-	readonly X: number;
+        readonly X: number;
     readonly Y: number;
 }
+
+// Basic input and animation enums used by GuiObject
+type EasingDirection = "In" | "Out" | "InOut";
+type EasingStyle =
+    | "Linear"
+    | "Sine"
+    | "Back"
+    | "Bounce"
+    | "Elastic"
+    | "Quad"
+    | "Quart"
+    | "Quint"
+    | "Exponential"
+    | "Circular"
+    | "Cubic";
+type TweenStatus = "Canceled" | "Completed";
+type SwipeDirection = "Left" | "Right" | "Up" | "Down";
+type UserInputState = "Begin" | "Change" | "End" | "Cancel";
+
+interface InputObject {}
 
 interface Instances {
 
@@ -128,7 +148,6 @@ interface Instance {
 	 */
 	GetDescendants(this: Instance): Array<Instance>;
 	/**
-	 * Returns a string describing the Instance's ancestry. The string is a concatenation of the [Name](https://developer.roblox.com/en-us/api-reference/property/Instance/Name) of the object and its ancestors, separated by periods.
 	 */
 	GetFullName(this: Instance): string;
 	/**
@@ -143,7 +162,6 @@ interface Instance {
      */
 	GetTags(this: Instance): Array<string>;
     /**
-     * Returns true if the Instance has a tag with the given name. Tags are a way to categorize and identify Instances without affecting their hierarchy or properties. Tags can be added using [Instance:AddTag](https://developer.roblox.com/en-us/api-reference/function/Instance/AddTag) and removed using [Instance:RemoveTag](https://developer.roblox.com/en-us/api-reference/function/Instance/RemoveTag).
      */
 	HasTag(this: Instance, tag: string): boolean;
 	/**
@@ -260,7 +278,6 @@ interface GuiObject extends GuiBase {
 	Draggable: boolean;
 	LayoutOrder: number;
 	/**
-	 * This property determines a GUI's pixel and scalar size using a `UDim2`. Its value can be expressed as `UDim2.new(ScalarX, PixelX, ScalarY, PixelY)` or `({ScalarX, PixelX}, {ScalarY, PixelY})`. Position is centered around a GUI's [GuiObject.AnchorPoint](https://developer.roblox.com/en-us/api-reference/property/GuiObject/AnchorPoint).
 	 * 
 	 * An element's position can also be set by modifying both its scalar and pixel positions at the same time. For instance, its position can be set to `({0.25, 100}, {0.25, 100})`.
 	 * 
@@ -268,46 +285,32 @@ interface GuiObject extends GuiBase {
 	 * 
 	 * The pixel portions of the `UDim2` value are the same regardless of the parent GUI's size. The values represent the position of the object in pixels. For example, if set to `{0, 100}, {0, 150}` the element's AnchorPoint will render with on the screen 100 pixels from the left and 150 pixels from the top.
 	 * 
-	 * An object's actual pixel position can be read from the [GuiBase2d.AbsolutePosition](https://developer.roblox.com/en-us/api-reference/property/GuiBase2d/AbsolutePosition) property.
 	 */
 	Position: UDim2;
 	/**
 	 * This property determines the number of degrees by which a GuiObject is rotated. Rotation is relative to the **center** of its parent GUI.
 	 * 
-	 * A GUI's [GuiObject.AnchorPoint](https://developer.roblox.com/en-us/api-reference/property/GuiObject/AnchorPoint) does not influence it's rotation. This means that you cannot change the center of rotation since it will always be in the center of the object.
 	 * 
-	 * Additionally, this property is **not compatible** with [GuiObject.ClipsDescendants](https://developer.roblox.com/en-us/api-reference/property/GuiObject/ClipsDescendants). If an ancestor (parent) object has ClipsDescendants enabled and this property is nonzero, then descendant GUI elements will not be clipped.
 	 */
 	Rotation: number;
 	/**
 	 * This property determines whether a ~GuiObject|GUI\` can be selected when navigating GUIs using a gamepad.
 	 * 
-	 * If this property is true, a GUI can be selected. Selecting a GUI also sets the [GuiService.SelectedObject](https://developer.roblox.com/en-us/api-reference/property/GuiService/SelectedObject) property to that object.
 	 * 
 	 * When this is false, the GUI cannot be selected. However, setting this to false when a GUI is selected will not deselect it nor change the value of the GuiService's SelectedObject property.
 	 * 
-	 * Add [GuiObject.SelectionGained](https://developer.roblox.com/en-us/api-reference/event/GuiObject/SelectionGained) and [GuiObject.SelectionLost](https://developer.roblox.com/en-us/api-reference/event/GuiObject/SelectionLost) will not fire for the element.  
-	 * To deselect a GuiObject, you must change [GuiService's](https://developer.roblox.com/en-us/api-reference/class/GuiService) SelectedObject property.
 	 * 
-	 * This property is useful if a GUI is connected to several GUIs via properties such as this [GuiObject.NextSelectionUp](https://developer.roblox.com/en-us/api-reference/property/GuiObject/NextSelectionUp), [GuiObject.NextSelectionDown](https://developer.roblox.com/en-us/api-reference/property/GuiObject/NextSelectionDown), [NextSelectionRight](https://developer.roblox.com/en-us/api-reference/class/GuiObject), or [NextSelectionLeft](https://developer.roblox.com/en-us/api-reference/class/GuiObject). Rather than change all of the properties so that the Gamepad cannot select the GUI, you can disable its Selectable property to temporarily prevent it from being selected. Then, when you want the gamepad selector to be able to select the GUI, simply re-enable its selectable property.
 	 */
 	Selectable: boolean;
 	/**
 	 * This property overrides the default selection adornment (used for gamepads). For best results, this should point to a GuiObject.
 	 * 
-	 * Note that the SelectionImageObject overlays the selected GUI with the GuiObject.Size of the image. For best results when using a non-default SelectionImageObject, you should size the SelectionImageObject via the scale [UDim2](https://developer.roblox.com/en-us/api-reference/datatype/UDim2) values. This helps ensure that the object scales properly over the selected element.
 	 * 
-	 * The default SelectionImageObject is a blue and white square outline around the selected GUI element. In the image below, the selected GUI is a white [Frame](https://developer.roblox.com/en-us/api-reference/class/Frame).
 	 * 
-	 * ![Default SelectionImageObject](https://developer.roblox.com/assets/bltae6b98faea42f3d1/Screen_Shot_2018-09-13_at_9.57.14_PM.png)
 	 * 
-	 * For instance, changing the SelectionImageObject to a [ImageLabel](https://developer.roblox.com/en-us/api-reference/class/ImageLabel) with red and white square outline [image](https://www.roblox.com/library/2347505468/SelectionImage-Red), [GuiObject.BackgroundTransparency](https://developer.roblox.com/en-us/api-reference/property/GuiObject/BackgroundTransparency) of 1, GuiObject.Size of _UDim2(1.1, 0, 1.1, 0)_, and GuiObject.Position of _UDim2(-0.05, 0, -0.05, 0)_ results in the image below:
 	 * 
-	 * ![Custom SelectionImageObject](https://developer.roblox.com/assets/blt5f5f0cf0d10b4e57/Screen_Shot_2018-09-13_at_9.53.54_PM.png)
 	 * 
-	 * Changing the SelectionImageObject for a GUI element only affects that element. To change the SelectionImageObject for all of a user's GUI elements, you can set the [PlayerGui.SelectionImageObject](https://developer.roblox.com/en-us/api-reference/property/PlayerGui/SelectionImageObject) property.
 	 * 
-	 * To determine or set which GUI element is selected by the user, you can use the [GuiService.SelectedObject](https://developer.roblox.com/en-us/api-reference/property/GuiService/SelectedObject) property. The user uses the gamepad to select different GUI elements, invoking the [GuiObject.NextSelectionUp](https://developer.roblox.com/en-us/api-reference/property/GuiObject/NextSelectionUp), [GuiObject.NextSelectionDown](https://developer.roblox.com/en-us/api-reference/property/GuiObject/NextSelectionDown), [GuiObject.NextSelectionLeft](https://developer.roblox.com/en-us/api-reference/property/GuiObject/NextSelectionLeft), and [GuiObject.NextSelectionRight](https://developer.roblox.com/en-us/api-reference/property/GuiObject/NextSelectionRight) events.
 	 */
 	SelectionImageObject: GuiObject | undefined;
 	SelectionOrder: number;
@@ -316,15 +319,12 @@ interface GuiObject extends GuiBase {
 	 */
 	Size: UDim2;
 	/**
-	 * This property works in conjunction with the [Size](https://developer.roblox.com/en-us/api-reference/class/GuiObject.Size) property to determine the screen size of a GUI element.
 	 * 
-	 * The [SizeConstraint](https://developer.roblox.com/en-us/api-reference/enum/SizeConstraint) enum will determine the axes that influence the scalar size of an object.
 	 * 
 	 * This property is useful for creating onscreen controls that are meant to scale with either the width or height of a parent object, but not both. This preserves the aspect ratio of the GUI element in question. For example, setting to RelativeYY with a Size of `{1, 0}, {1, 0}` will make the UI element square, with both the X and Y sizes equal to the parent element's Y size.
 	 */
-	SizeConstraint: Enum.SizeConstraint;
+        SizeConstraint: SizeConstraint;
 	/**
-	 * This property is deprecated, and a mix of [GuiObject.BackgroundTransparency](https://developer.roblox.com/en-us/api-reference/property/GuiObject/BackgroundTransparency) and [TextLabel.TextTransparency](https://developer.roblox.com/en-us/api-reference/property/TextLabel/TextTransparency).
 	 * 
 	 * When indexing, this will return the BackgroundTranparency.
 	 * 
@@ -336,9 +336,7 @@ interface GuiObject extends GuiBase {
 	/**
 	 * This property determines whether a GuiObject will render shapes, images and/or text on screen. If set to false, the GUI and all of its descedants (children) will not render.
 	 * 
-	 * The rendering of individual components of a GUI can be controlled individually through transparency properties such as [GuiObject.BackgroundTransparency](https://developer.roblox.com/en-us/api-reference/property/GuiObject/BackgroundTransparency), [TextLabel.TextTransparency](https://developer.roblox.com/en-us/api-reference/property/TextLabel/TextTransparency) and [ImageLabel.ImageTransparency](https://developer.roblox.com/en-us/api-reference/property/ImageLabel/ImageTransparency).
 	 * 
-	 * When this property is true, the GUI will be ignored by [UIGridStyleLayout](https://developer.roblox.com/en-us/api-reference/class/UIGridStyleLayout) objects (such as [UIGridLayout](https://developer.roblox.com/en-us/api-reference/class/UIGridLayout), [UIListLayout](https://developer.roblox.com/en-us/api-reference/class/UIListLayout) and [UITableLayout](https://developer.roblox.com/en-us/api-reference/class/UITableLayout)). In other words, the space that the element would otherwise occupy in the layout is used by other elements instead.
 	 */
 	Visible: boolean;
 	/**
@@ -351,69 +349,59 @@ interface GuiObject extends GuiBase {
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.LayoutOrder](https://developer.roblox.com/en-us/api-reference/property/GuiObject/LayoutOrder), which controls the sort order of a GUI when used with a [UIGridStyleLayout](https://developer.roblox.com/en-us/api-reference/class/UIGridStyleLayout) instead of render order.
 	 */
 	ZIndex: number;
 	/**
-	 * Smoothly moves a GUI to a new [UDim2](https://developer.roblox.com/en-us/api-reference/datatype/UDim2) position in the specified time using the specified [EasingDirection](https://developer.roblox.com/en-us/api-reference/enum/EasingDirection) and [EasingStyle](https://developer.roblox.com/en-us/api-reference/enum/EasingStyle).
 	 * 
 	 * This function will return whether the tween will play. It will not play if another tween is acting on the GuiObject and the override parameter is false.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject:TweenSize](https://developer.roblox.com/en-us/api-reference/function/GuiObject/TweenSize), tweens a GUI's size
-	 * *   [GuiObject:TweenSizeAndPosition](https://developer.roblox.com/en-us/api-reference/function/GuiObject/TweenSizeAndPosition), tweens a GUI's size and position synchronously
 	 */
 	TweenPosition(
 		this: GuiObject,
 		endPosition: UDim2,
-		easingDirection?: CastsToEnum<Enum.EasingDirection>,
-		easingStyle?: CastsToEnum<Enum.EasingStyle>,
+                easingDirection?: EasingDirection,
+                easingStyle?: EasingStyle,
 		time?: number,
 		override?: boolean,
-		callback?: (finishedTween: Enum.TweenStatus) => void,
+                callback?: (finishedTween: TweenStatus) => void,
 	): boolean;
 	/**
-	 * Smoothly resizes a GUI to a new [UDim2](https://developer.roblox.com/en-us/api-reference/datatype/UDim2) in the specified time using the specified [EasingDirection](https://developer.roblox.com/en-us/api-reference/enum/EasingDirection) and [EasingStyle](https://developer.roblox.com/en-us/api-reference/enum/EasingStyle).
 	 * 
 	 * This function will return whether the tween will play. Normally this will always return true, but it will return false if another tween is active and override is set to false.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject:TweenPosition](https://developer.roblox.com/en-us/api-reference/function/GuiObject/TweenPosition), tweens a GUI's position
-	 * *   [GuiObject:TweenSizeAndPosition](https://developer.roblox.com/en-us/api-reference/function/GuiObject/TweenSizeAndPosition), tweens a GUI's size and position synchronously
 	 */
 	TweenSize(
 		this: GuiObject,
 		endSize: UDim2,
-		easingDirection?: CastsToEnum<Enum.EasingDirection>,
-		easingStyle?: CastsToEnum<Enum.EasingStyle>,
+                easingDirection?: EasingDirection,
+                easingStyle?: EasingStyle,
 		time?: number,
 		override?: boolean,
-		callback?: (finishedTween: Enum.TweenStatus) => void,
+                callback?: (finishedTween: TweenStatus) => void,
 	): boolean;
 	/**
-	 * Smoothly resizes and moves a GUI to a new [UDim2](https://developer.roblox.com/en-us/api-reference/datatype/UDim2) size and position in the specified time using the specified [EasingDirection](https://developer.roblox.com/en-us/api-reference/enum/EasingDirection) and [EasingStyle](https://developer.roblox.com/en-us/api-reference/enum/EasingStyle).
 	 * 
 	 * This function will return whether the tween will play. Normally this will always return true, but it will return false if another tween is active and override is set to false.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject:TweenSize](https://developer.roblox.com/en-us/api-reference/function/GuiObject/TweenSize), tweens a GUI's size
-	 * *   [GuiObject:TweenPosition](https://developer.roblox.com/en-us/api-reference/function/GuiObject/TweenPosition), tweens a GUI's position
 	 */
 	TweenSizeAndPosition(
 		this: GuiObject,
 		endSize: UDim2,
 		endPosition: UDim2,
-		easingDirection?: CastsToEnum<Enum.EasingDirection>,
-		easingStyle?: CastsToEnum<Enum.EasingStyle>,
+                easingDirection?: EasingDirection,
+                easingStyle?: EasingStyle,
 		time?: number,
 		override?: boolean,
-		callback?: (finishedTween: Enum.TweenStatus) => void,
+                callback?: (finishedTween: TweenStatus) => void,
 	): boolean;
 	/**
 	 * This event fires when a player begins dragging the object.
@@ -421,62 +409,51 @@ interface GuiObject extends GuiBase {
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.DragStopped](https://developer.roblox.com/en-us/api-reference/event/GuiObject/DragStopped)
 	 * @deprecated
 	 */
-	readonly DragBegin: RBXScriptSignal<(initialPosition: UDim2) => void>;
+        readonly DragBegin: IEvent<{ initialPosition: UDim2 }>;
 	/**
 	 * This event fires when a player stops dragging the object.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.DragBegin](https://developer.roblox.com/en-us/api-reference/event/GuiObject/DragBegin)
 	 * @deprecated
 	 */
-	readonly DragStopped: RBXScriptSignal<(x: number, y: number) => void>;
+        readonly DragStopped: IEvent<{ x: number; y: number }>;
 	/**
 	 * This event fires when a user begins interacting with the GuiObject via a Human-Computer Interface device (Mouse button down, touch begin, keyboard button down, etc).
 	 * 
-	 * The [UserInputService](https://developer.roblox.com/en-us/api-reference/class/UserInputService) has a similarly named event that is not restricted to a specific UI element: [UserInputService.InputBegan](https://developer.roblox.com/en-us/api-reference/event/UserInputService/InputBegan).
 	 * 
 	 * This event will always fire regardless of game state.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.InputEnded](https://developer.roblox.com/en-us/api-reference/event/GuiObject/InputEnded)
-	 * *   [GuiObject.InputChanged](https://developer.roblox.com/en-us/api-reference/event/GuiObject/InputChanged)
 	 */
-	readonly InputBegan: RBXScriptSignal<(input: InputObject) => void>;
+        readonly InputBegan: IEvent<{ input: InputObject }>;
 	/**
 	 * This event fires when a user changes how they're interacting via a Human-Computer Interface device (Mouse button down, touch begin, keyboard button down, etc).
 	 * 
-	 * The [UserInputService](https://developer.roblox.com/en-us/api-reference/class/UserInputService) has a similarly named event that is not restricted to a specific UI element: [UserInputService.InputChanged](https://developer.roblox.com/en-us/api-reference/event/UserInputService/InputChanged).
 	 * 
 	 * This event will always fire regardless of game state.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.InputBegan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/InputBegan)
-	 * *   [GuiObject.InputEnded](https://developer.roblox.com/en-us/api-reference/event/GuiObject/InputEnded)
 	 */
-	readonly InputChanged: RBXScriptSignal<(input: InputObject) => void>;
+        readonly InputChanged: IEvent<{ input: InputObject }>;
 	/**
 	 * The InputEnded event fires when a user stops interacting via a Human-Computer Interface device (Mouse button down, touch begin, keyboard button down, etc).
 	 * 
-	 * The [UserInputService](https://developer.roblox.com/en-us/api-reference/class/UserInputService) has a similarly named event that is not restricted to a specific UI element: [UserInputService.InputEnded](https://developer.roblox.com/en-us/api-reference/event/UserInputService/InputEnded).
 	 * 
 	 * This event will always fire regardless of game state.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.InputBegan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/InputBegan)
-	 * *   [GuiObject.InputChanged](https://developer.roblox.com/en-us/api-reference/event/GuiObject/InputChanged)
 	 */
-	readonly InputEnded: RBXScriptSignal<(input: InputObject) => void>;
+        readonly InputEnded: IEvent<{ input: InputObject }>;
 	/**
 	 * The MouseEnter event fires when a user moves their mouse into a GuiObject element.
 	 * 
@@ -484,17 +461,12 @@ interface GuiObject extends GuiBase {
 	 * 
 	 * This event fires even when the GUI element renders beneath another element.
 	 * 
-	 * If you would like to track when a user's mouse leaves a GUI element, you can use the [GuiObject.MouseLeave](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseLeave) event.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.MouseLeave](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseLeave)
-	 * *   [GuiObject.MouseMoved](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseMoved)
-	 * *   [GuiObject.MouseWheelForward](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseWheelForward)
-	 * *   [GuiObject.MouseWheelBackward](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseWheelBackward)
 	 */
-	readonly MouseEnter: RBXScriptSignal<(x: number, y: number) => void>;
+        readonly MouseEnter: IEvent<{ x: number; y: number }>;
 	/**
 	 * The MouseLeave event fires when a user moves their mouse out of a GuiObject element.
 	 * 
@@ -505,20 +477,14 @@ interface GuiObject extends GuiBase {
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.MouseEnter](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseEnter)
-	 * *   [GuiObject.MouseMoved](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseMoved)
-	 * *   [GuiObject.MouseWheelForward](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseWheelForward)
-	 * *   [GuiObject.MouseWheelBackward](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseWheelBackward)
 	 */
-	readonly MouseLeave: RBXScriptSignal<(x: number, y: number) => void>;
+        readonly MouseLeave: IEvent<{ x: number; y: number }>;
 	/**
-	 * Fires whenever a user moves their mouse while it is inside a GuiObject element. It is similar to [Mouse.Move](https://developer.roblox.com/en-us/api-reference/event/Mouse/Move), which fires regardless whether the user's mouse is over a GUI element.
 	 * 
 	 * Note, this event fires when the mouse's position is updated, therefore it will fire repeatedly whilst being moved.
 	 * 
 	 * The `x` and `y` arguments indicate the updated screen coordinates of the user's mouse in pixels. These can be useful to determine the mouse's location on the GUI, screen, and delta since the mouse's previous position if it is being tracked in a global variable.
 	 * 
-	 * The code below demonstrates how to determine the [Vector2](https://developer.roblox.com/en-us/api-reference/datatype/Vector2) offset of the user's mouse relative to a GUI element:
 	 * 
 	 * local CustomScrollingFrame = script.Parent
 	 * local SubFrame = CustomScrollingFrame:FindFirstChild("SubFrame")
@@ -540,176 +506,113 @@ interface GuiObject extends GuiBase {
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.MouseEnter](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseEnter)
-	 * *   [GuiObject.MouseLeave](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseLeave)
-	 * *   [GuiObject.MouseWheelForward](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseWheelForward)
-	 * *   [GuiObject.MouseWheelBackward](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseWheelBackward)
 	 */
-	readonly MouseMoved: RBXScriptSignal<(x: number, y: number) => void>;
+        readonly MouseMoved: IEvent<{ x: number; y: number }>;
 	/**
-	 * The WheelBackward event fires when a user scrolls their mouse wheel back when the mouse is over a GuiObject element. It is similar to [Mouse.WheelBackward](https://developer.roblox.com/en-us/api-reference/event/Mouse/WheelBackward), which fires regardless whether the user's mouse is over a GUI element.
 	 * 
-	 * This event fires merely as an indicator of the wheel's forward movement. This means that the x and y mouse coordinate arguments do not change as a result of this event. These coordinates only change when the mouse moves, which can be tracked by the [GuiObject.MouseMoved](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseMoved) event.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.MouseEnter](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseEnter)
-	 * *   [GuiObject.MouseLeave](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseLeave)
-	 * *   [GuiObject.MouseMoved](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseMoved)
-	 * *   [GuiObject.MouseWheelForward](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseWheelForward)
 	 */
-	readonly MouseWheelBackward: RBXScriptSignal<(x: number, y: number) => void>;
+        readonly MouseWheelBackward: IEvent<{ x: number; y: number }>;
 	/**
-	 * The WheelForward event fires when a user scrolls their mouse wheel forward when the mouse is over a GuiObject element. It is similar to [Mouse.WheelForward](https://developer.roblox.com/en-us/api-reference/event/Mouse/WheelForward), which fires regardless whether the user's mouse is over a GUI element.
 	 * 
-	 * This event fires merely as an indicator of the wheel's forward movement. This means that the x and y mouse coordinate arguments do not change as a result of this event. These coordinates only change when the mouse moves, which can be tracked by the [GuiObject.MouseMoved](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseMoved) event.
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.MouseEnter](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseEnter)
-	 * *   [GuiObject.MouseLeave](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseLeave)
-	 * *   [GuiObject.MouseMoved](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseMoved)
-	 * *   [GuiObject.MouseWheelBackward](https://developer.roblox.com/en-us/api-reference/event/GuiObject/MouseWheelBackward)
 	 */
-	readonly MouseWheelForward: RBXScriptSignal<(x: number, y: number) => void>;
+        readonly MouseWheelForward: IEvent<{ x: number; y: number }>;
 	/**
 	 * This event fires when the Gamepad selector starts focusing on the GuiObject.
 	 * 
-	 * If you want to check from the Gamepad select stops focusing on the GUI element, you can use the [GuiObject.SelectionLost](https://developer.roblox.com/en-us/api-reference/event/GuiObject/SelectionLost) event.
 	 * 
 	 * When a GUI gains selection focus, the value of the `GuiService/SelectionObject|SelectionObject` property also changes to the that gains selection. To determine which GUI gained selection, check the value of this property.
 	 */
-	readonly SelectionGained: RBXScriptSignal<() => void>;
+        readonly SelectionGained: IEvent<void>;
 	/**
 	 * This event fires when the Gamepad selector stops focusing on the GuiObject.
 	 * 
-	 * If you want to check from the Gamepad select starts focusing on the GUI element, you can use the [GuiObject.SelectionGained](https://developer.roblox.com/en-us/api-reference/event/GuiObject/SelectionGained) event.
 	 * 
 	 * When a GUI loses selection focus, the value of the `GuiService/SelectionObject|SelectionObject` property changes either to nil or to the GUI element that gains selection focus. To determine which GUI gained selection, or if no GUI is selected, check the value of this property.
 	 */
-	readonly SelectionLost: RBXScriptSignal<() => void>;
+        readonly SelectionLost: IEvent<void>;
 	/**
-	 * The TouchLongPress event fires after a brief moment when the player holds their finger on the UI element using a touch-enabled device. It fires with a table of [Vector2](https://developer.roblox.com/en-us/api-reference/datatype/Vector2) that describe the relative screen positions of the fingers involved in the gesture. In addition, it fires multiple times with multiple [UserInputState](https://developer.roblox.com/en-us/api-reference/enum/UserInputState)s: Begin after a brief delay, Change if the player moves their finger during the gesture and finally with End. The delay is platform dependent; in Studio it is a little longer than one second.
 	 * 
 	 * Since this event only requires one finger, this event can be simulated in Studio using the emulator and a mouse.
 	 * 
-	 * Below is an example of TouchLongPress firing on a Frame that is [GuiObject.Active](https://developer.roblox.com/en-us/api-reference/property/GuiObject/Active). Below, the event fires after a brief delay (Begin) and then continually as as the finger is moved (Change). It fires one last time after it is released (End).
 	 * 
-	 * ![TouchLongPress gesture](https://developer.roblox.com/assets/blt072ee7f898e2b645/GuiObjectTouchLongPressDemo.gif)
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [UserInputService.TouchLongPress](https://developer.roblox.com/en-us/api-reference/event/UserInputService/TouchLongPress), an event with the same functionality but is not restricted to a specific GuiObject
-	 * *   [GuiObject.TouchPan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPan)
-	 * *   [GuiObject.TouchPinch](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPinch)
-	 * *   [GuiObject.TouchRotate](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchRotate)
-	 * *   [GuiObject.TouchTap](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchTap)
-	 * *   [GuiObject.TouchSwipe](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchSwipe)
 	 */
-	readonly TouchLongPress: RBXScriptSignal<(touchPositions: Array<Vector2>, state: Enum.UserInputState) => void>;
+        readonly TouchLongPress: IEvent<{ touchPositions: Array<Vector2>; state: UserInputState }>;
 	/**
-	 * This event fires when the player moves their finger on the UI element using a touch-enabled device. It fires shortly before [GuiObject.TouchSwipe](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchSwipe) would, and does not fire with [GuiObject.TouchTap](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchTap). This event is useful for allowing the player to manipulate the position of UI elements on the screen.
 	 * 
-	 * This event fires with a table of [Vector2](https://developer.roblox.com/en-us/api-reference/datatype/Vector2) that describe the relative screen positions of the fingers involved in the gesture. In addition, it fires several times with multiple [UserInputState](https://developer.roblox.com/en-us/api-reference/enum/UserInputState)s: Begin after a brief delay, Change when the player moves their finger during the gesture and finally once more with End.
 	 * 
 	 * This event cannot be simulated in Studio using the emulator and a mouse; you must have a real touch enabled device to fire this event.
 	 * 
-	 * Below is an animation of TouchPan firing on the black semitransparent [Frame](https://developer.roblox.com/en-us/api-reference/class/Frame) that covers the screen. The event is being used to manipulate the position of the pink inner [Frame](https://developer.roblox.com/en-us/api-reference/class/Frame). The code for this can be found in the code samples.
 	 * 
-	 * ![TouchPan firing on a real touch-enabled device](https://developer.roblox.com/assets/bltd08f63e0a28873f4/GuiObjectTouchPanDemo.gif)
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.TouchPinch](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPinch)
-	 * *   [GuiObject.TouchRotate](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchRotate)
-	 * *   [GuiObject.TouchTap](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchTap)
-	 * *   [GuiObject.TouchSwipe](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchSwipe)
-	 * *   [GuiObject.TouchLongPress](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchLongPress)
 	 */
-	readonly TouchPan: RBXScriptSignal<
-		(
-			touchPositions: Array<Vector2>,
-			totalTranslation: Vector2,
-			velocity: Vector2,
-			state: Enum.UserInputState,
-		) => void
-	>;
+        readonly TouchPan: IEvent<{
+                touchPositions: Array<Vector2>;
+                totalTranslation: Vector2;
+                velocity: Vector2;
+                state: UserInputState;
+        }>;
 	/**
-	 * The TouchPinch event fires when the player uses two fingers to make a pinch or pull gesture on the UI element using a touch-enabled device. A **pinch** happens when two or more fingers move closer together, and a **pull** happens when they move apart. This event fires in conjunction with [GuiObject.TouchPan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPan). This event is useful for allowing the player to manipulate the scale (size) of UI elements on the screen, and is most often used for zooming features.
 	 * 
-	 * This event fires with a table of [Vector2](https://developer.roblox.com/en-us/api-reference/datatype/Vector2) that describe the relative screen positions of the fingers involved in the gesture. In addition, it fires several times with multiple [UserInputState](https://developer.roblox.com/en-us/api-reference/enum/UserInputState)s: Begin after a brief delay, Change when the player moves a finger during the gesture and finally once more with End. It should be noted that the scale should be used **multiplicatively**.
 	 * 
-	 * Since this event requires at least two fingers, it is not possible to be simulated in Studio using the emulator and a mouse; you must have a real touch-enabled device (and also least two fingers, try asking a friend). Below is an animation of TouchPinch firing on the black semitransparent [Frame](https://developer.roblox.com/en-us/api-reference/class/Frame) that covers the screen (note the touch positions marked with white circles). The event is being used to manipulate the scale of the [TextLabel](https://developer.roblox.com/en-us/api-reference/class/TextLabel) that says “Hi!”. The code for this can be found in the code samples.
 	 * 
-	 * ![TouchPinch firing on a real touch device](https://developer.roblox.com/assets/blt0f7f12dc386d161f/GuiObjectTouchPinchDemo.gif)
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.TouchPan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPan)
-	 * *   [GuiObject.TouchRotate](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchRotate)
-	 * *   [GuiObject.TouchTap](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchTap)
-	 * *   [GuiObject.TouchSwipe](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchSwipe)
-	 * *   [GuiObject.TouchLongPress](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchLongPress)
 	 */
-	readonly TouchPinch: RBXScriptSignal<
-		(touchPositions: Array<Vector2>, scale: number, velocity: number, state: Enum.UserInputState) => void
-	>;
+        readonly TouchPinch: IEvent<{
+                touchPositions: Array<Vector2>;
+                scale: number;
+                velocity: number;
+                state: UserInputState;
+        }>;
 	/**
-	 * The TouchRotate event fires when the player uses two fingers to make a pinch or pull gesture on the UI element using a touch-enabled device. Rotation occurs when the angle of the line between two fingers changes. This event fires in conjunction with [GuiObject.TouchPan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPan). This event is useful for allowing the player to manipulate the rotation of UI elements on the screen.
 	 * 
-	 * This event fires with a table of [Vector2](https://developer.roblox.com/en-us/api-reference/datatype/Vector2) that describe the relative screen positions of the fingers involved in the gesture. In addition, it fires several times with multiple [UserInputState](https://developer.roblox.com/en-us/api-reference/enum/UserInputState)s: Begin after a brief delay, Change when the player moves a finger during the gesture and finally once more with End.
 	 * 
 	 * Since this event requires at least two fingers, it is not possible to be simulated in Studio using the emulator and a mouse; you must have a real touch-enabled device (and also least two fingers, try asking a friend).
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.TouchPan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPan)
-	 * *   [GuiObject.TouchPinch](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPinch)
-	 * *   [GuiObject.TouchTap](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchTap)
-	 * *   [GuiObject.TouchSwipe](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchSwipe)
-	 * *   [GuiObject.TouchLongPress](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchLongPress)
 	 */
-	readonly TouchRotate: RBXScriptSignal<
-		(touchPositions: Array<Vector2>, rotation: number, velocity: number, state: Enum.UserInputState) => void
-	>;
+        readonly TouchRotate: IEvent<{
+                touchPositions: Array<Vector2>;
+                rotation: number;
+                velocity: number;
+                state: UserInputState;
+        }>;
 	/**
 	 * The TouchSwipe event fires when the player performs a swipe gesture on the UI element using a touch-enabled device. It fires with the direction of the gesture (Up, Down, Left or Right) and the number of touch points involved in the gesture. Swipe gestures are often used to change tabs in mobile UIs.
 	 * 
-	 * Since this event only requires one finger, this event can be simulated in Studio using the emulator and a mouse. Below is an example of TouchSwipe being fired on a Frame that is [GuiObject.Active](https://developer.roblox.com/en-us/api-reference/property/GuiObject/Active). Below, the event fires when the Frame moves and changes color slightly. The code for this can be found the code samples.
 	 * 
-	 * ![TouchSwipe event firing on a Frame](https://developer.roblox.com/assets/blt674fae3d52e692b7/GuiObjectTouchSwipeDemo.gif)
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.TouchPan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPan)
-	 * *   [GuiObject.TouchPinch](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPinch)
-	 * *   [GuiObject.TouchRotate](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchRotate)
-	 * *   [GuiObject.TouchTap](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchTap)
-	 * *   [GuiObject.TouchLongPress](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchLongPress)
 	 */
-	readonly TouchSwipe: RBXScriptSignal<(swipeDirection: Enum.SwipeDirection, numberOfTouches: number) => void>;
+        readonly TouchSwipe: IEvent<{ swipeDirection: SwipeDirection; numberOfTouches: number }>;
 	/**
-	 * The TouchTap event fires when the player performs a tap gesture on the UI element using a touch-enabled device. A tap is a quick single touch without any movement involved (a longer press would fire [GuiObject.TouchLongPress](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchLongPress), and moving during the touch would fire [GuiObject.TouchPan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPan) and/or [GuiObject.TouchSwipe](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchSwipe)). It fires with a table of [Vector2](https://developer.roblox.com/en-us/api-reference/datatype/Vector2)s that describe the relative positions of the fingers involved in the gesture.
 	 * 
-	 * Since this event only requires one finger, this event can be simulated in Studio using the emulator and a mouse. Below is an example of TouchTap being fired on a Frame that is [GuiObject.Active](https://developer.roblox.com/en-us/api-reference/property/GuiObject/Active). Below, the event fires when the cursor briefly pauses (to simulate a tap) and the Frame toggles its [GuiObject.BackgroundTransparency](https://developer.roblox.com/en-us/api-reference/property/GuiObject/BackgroundTransparency). The code for this can be found the code samples.
 	 * 
-	 * ![TouchTap being fired on a Frame using Studio's emulator](https://developer.roblox.com/assets/blt248e4176c17eb486/GuiObjectTouchTapDemo.gif)
 	 * 
 	 * See also
 	 * --------
 	 * 
-	 * *   [GuiObject.TouchPan](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPan)
-	 * *   [GuiObject.TouchPinch](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchPinch)
-	 * *   [GuiObject.TouchRotate](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchRotate)
-	 * *   [GuiObject.TouchSwipe](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchSwipe)
-	 * *   [GuiObject.TouchLongPress](https://developer.roblox.com/en-us/api-reference/event/GuiObject/TouchLongPress)
 	 */
-	readonly TouchTap: RBXScriptSignal<(touchPositions: Array<Vector2>) => void>;
+        readonly TouchTap: IEvent<{ touchPositions: Array<Vector2> }>;
 }


### PR DESCRIPTION
## Summary
- expand widget type definitions with local enums and InputObject
- strip Roblox links from type docs
- implement abstract `GuiBase` and `GuiObject` classes following `Inst`
- provide placeholder tween and event handling

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6861b4761e30832e98a64a95136e6ad5