### PR TITLE
Implement additional GUI widget classes

### DIFF
--- a/src/engine/InstanceManager.ts
+++ b/src/engine/InstanceManager.ts
@@ -1,9 +1,19 @@
 import { FrameWidget } from "./widgets/Frame";
 import { RootWidget } from "./widgets/RootWidget";
+import { CanvasGroupWidget } from "./widgets/CanvasGroup";
+import { GuiButtonWidget } from "./widgets/GuiButton";
+import { GuiLabelWidget } from "./widgets/GuiLabel";
+import { ScrollingFrameWidget } from "./widgets/ScrollingFrame";
+import { TextBoxWidget } from "./widgets/TextBox";
 
 const classMap: { [K in keyof Instances]: new (name: string) => Instances[K] } = {
     Frame: FrameWidget as any,
     RootWidget: RootWidget as any,
+    CanvasGroup: CanvasGroupWidget as any,
+    GuiButton: GuiButtonWidget as any,
+    GuiLabel: GuiLabelWidget as any,
+    ScrollingFrame: ScrollingFrameWidget as any,
+    TextBox: TextBoxWidget as any,
 };
 
 let root: RootWidget | undefined;

--- a/src/engine/widgets/CanvasGroup.ts
+++ b/src/engine/widgets/CanvasGroup.ts
@@ -1,0 +1,36 @@
+import { AGuiObject } from "./GuiObject";
+
+export class CanvasGroupWidget extends AGuiObject implements CanvasGroup {
+    private _groupColor3: Color3 = { R: 1, G: 1, B: 1 };
+    private _groupTransparency = 0;
+
+    protected static DefaultProperties = {
+        ...AGuiObject.DefaultProperties,
+        _groupColor3: { R: 1, G: 1, B: 1 },
+        _groupTransparency: 0,
+    };
+
+    public constructor(name: string) {
+        super(name, "CanvasGroup");
+    }
+
+    public get GroupColor3(): Color3 {
+        return this._groupColor3;
+    }
+    public set GroupColor3(v: Color3) {
+        this._groupColor3 = v;
+        this.signalPropertyChanged("GroupColor3");
+    }
+
+    public get GroupTransparency(): number {
+        return this._groupTransparency;
+    }
+    public set GroupTransparency(v: number) {
+        this._groupTransparency = v;
+        this.signalPropertyChanged("GroupTransparency");
+    }
+
+    public Draw(): void {
+        // CanvasGroup does not render anything by itself
+    }
+}

--- a/src/engine/widgets/GuiButton.ts
+++ b/src/engine/widgets/GuiButton.ts
@@ -1,0 +1,101 @@
+import { Event } from "../core/Event";
+import { AGuiObject } from "./GuiObject";
+
+export class GuiButtonWidget extends AGuiObject implements GuiButton {
+    private _autoButtonColor = true;
+    private _modal = false;
+    private _selected = false;
+    private _style: any = undefined;
+
+    protected static DefaultProperties = {
+        ...AGuiObject.DefaultProperties,
+        _autoButtonColor: true,
+        _modal: false,
+        _selected: false,
+        _style: undefined as any,
+    };
+
+    public readonly Activated = new Event<(inputObject: InputObject, clickCount: number) => void>();
+    public readonly MouseButton1Click = new Event<() => void>();
+    public readonly MouseButton1Down = new Event<(x: number, y: number) => void>();
+    public readonly MouseButton1Up = new Event<(x: number, y: number) => void>();
+    public readonly MouseButton2Click = new Event<() => void>();
+    public readonly MouseButton2Down = new Event<(x: number, y: number) => void>();
+    public readonly MouseButton2Up = new Event<(x: number, y: number) => void>();
+
+    public constructor(name: string) {
+        super(name, "GuiButton");
+    }
+
+    public get AutoButtonColor(): boolean {
+        return this._autoButtonColor;
+    }
+    public set AutoButtonColor(v: boolean) {
+        this._autoButtonColor = v;
+        this.signalPropertyChanged("AutoButtonColor");
+    }
+
+    public get Modal(): boolean {
+        return this._modal;
+    }
+    public set Modal(v: boolean) {
+        this._modal = v;
+        this.signalPropertyChanged("Modal");
+    }
+
+    public get Selected(): boolean {
+        return this._selected;
+    }
+    public set Selected(v: boolean) {
+        this._selected = v;
+        this.signalPropertyChanged("Selected");
+    }
+
+    public get Style(): any {
+        return this._style;
+    }
+    public set Style(v: any) {
+        this._style = v;
+        this.signalPropertyChanged("Style");
+    }
+
+    public Draw(): void {
+        if (!this.Visible) return;
+
+        love.graphics.push();
+        love.graphics.translate(
+            this.AbsolutePosition.X + this.AbsoluteSize.X / 2,
+            this.AbsolutePosition.Y + this.AbsoluteSize.Y / 2,
+        );
+        love.graphics.rotate(this.AbsoluteRotation * (Math.PI / 180));
+        love.graphics.translate(-this.AbsoluteSize.X / 2, -this.AbsoluteSize.Y / 2);
+
+        const totalAlpha = 1 - Math.min(1, this.BackgroundTransparency + this.Transparency);
+        const c = this.BackgroundColor3;
+        love.graphics.setColor(c.R, c.G, c.B, totalAlpha);
+        love.graphics.rectangle("fill", 0, 0, this.AbsoluteSize.X, this.AbsoluteSize.Y);
+
+        if (this.BorderSizePixel > 0) {
+            const bc = this.BorderColor3;
+            love.graphics.setColor(bc.R, bc.G, bc.B, totalAlpha);
+            love.graphics.setLineWidth(this.BorderSizePixel);
+            let off = 0;
+            if (this.BorderMode === "Inset") {
+                off = this.BorderSizePixel;
+            } else if (this.BorderMode === "Middle") {
+                off = this.BorderSizePixel / 2;
+            } else {
+                off = 0;
+            }
+            love.graphics.rectangle(
+                "line",
+                -off / 2,
+                -off / 2,
+                this.AbsoluteSize.X + off,
+                this.AbsoluteSize.Y + off,
+            );
+        }
+
+        love.graphics.pop();
+    }
+}

--- a/src/engine/widgets/GuiLabel.ts
+++ b/src/engine/widgets/GuiLabel.ts
@@ -1,0 +1,51 @@
+import { AGuiObject } from "./GuiObject";
+
+export class GuiLabelWidget extends AGuiObject implements GuiLabel {
+    protected static DefaultProperties = {
+        ...AGuiObject.DefaultProperties,
+    };
+
+    public constructor(name: string) {
+        super(name, "GuiLabel");
+    }
+
+    public Draw(): void {
+        if (!this.Visible) return;
+
+        love.graphics.push();
+        love.graphics.translate(
+            this.AbsolutePosition.X + this.AbsoluteSize.X / 2,
+            this.AbsolutePosition.Y + this.AbsoluteSize.Y / 2,
+        );
+        love.graphics.rotate(this.AbsoluteRotation * (Math.PI / 180));
+        love.graphics.translate(-this.AbsoluteSize.X / 2, -this.AbsoluteSize.Y / 2);
+
+        const totalAlpha = 1 - Math.min(1, this.BackgroundTransparency + this.Transparency);
+        const c = this.BackgroundColor3;
+        love.graphics.setColor(c.R, c.G, c.B, totalAlpha);
+        love.graphics.rectangle("fill", 0, 0, this.AbsoluteSize.X, this.AbsoluteSize.Y);
+
+        if (this.BorderSizePixel > 0) {
+            const bc = this.BorderColor3;
+            love.graphics.setColor(bc.R, bc.G, bc.B, totalAlpha);
+            love.graphics.setLineWidth(this.BorderSizePixel);
+            let off = 0;
+            if (this.BorderMode === "Inset") {
+                off = this.BorderSizePixel;
+            } else if (this.BorderMode === "Middle") {
+                off = this.BorderSizePixel / 2;
+            } else {
+                off = 0;
+            }
+            love.graphics.rectangle(
+                "line",
+                -off / 2,
+                -off / 2,
+                this.AbsoluteSize.X + off,
+                this.AbsoluteSize.Y + off,
+            );
+        }
+
+        love.graphics.pop();
+    }
+}

--- a/src/engine/widgets/ScrollingFrame.ts
+++ b/src/engine/widgets/ScrollingFrame.ts
@@ -1,0 +1,224 @@
+import { AGuiObject } from "./GuiObject";
+
+export class ScrollingFrameWidget extends AGuiObject implements ScrollingFrame {
+    private _automaticCanvasSize: AutomaticSize = "None";
+    private _bottomImage = "";
+    private _canvasPosition: Vector2 = { X: 0, Y: 0 };
+    private _canvasSize: UDim2 = { X: { Scale: 0, Pixel: 0 }, Y: { Scale: 0, Pixel: 0 } };
+    private _elasticBehavior: any = "WhenScrollable";
+    private _horizontalScrollBarInset: any = undefined;
+    private _midImage = "";
+    private _scrollBarImageColor3: Color3 = { R: 1, G: 1, B: 1 };
+    private _scrollBarImageTransparency = 0;
+    private _scrollBarThickness = 10;
+    private _scrollingDirection: any = "XY";
+    private _scrollingEnabled = true;
+    private _topImage = "";
+    private _verticalScrollBarInset: any = undefined;
+    private _verticalScrollBarPosition: any = "Right";
+
+    private _absoluteCanvasSize: Vector2 = { X: 0, Y: 0 };
+    private _absoluteWindowSize: Vector2 = { X: 0, Y: 0 };
+
+    protected static DefaultProperties = {
+        ...AGuiObject.DefaultProperties,
+        _automaticCanvasSize: "None" as AutomaticSize,
+        _bottomImage: "",
+        _canvasPosition: { X: 0, Y: 0 },
+        _canvasSize: { X: { Scale: 0, Pixel: 0 }, Y: { Scale: 0, Pixel: 0 } },
+        _elasticBehavior: "WhenScrollable" as any,
+        _horizontalScrollBarInset: undefined as any,
+        _midImage: "",
+        _scrollBarImageColor3: { R: 1, G: 1, B: 1 },
+        _scrollBarImageTransparency: 0,
+        _scrollBarThickness: 10,
+        _scrollingDirection: "XY" as any,
+        _scrollingEnabled: true,
+        _topImage: "",
+        _verticalScrollBarInset: undefined as any,
+        _verticalScrollBarPosition: "Right" as any,
+        _absoluteCanvasSize: { X: 0, Y: 0 },
+        _absoluteWindowSize: { X: 0, Y: 0 },
+    };
+
+    public constructor(name: string) {
+        super(name, "ScrollingFrame");
+    }
+
+    public get AbsoluteCanvasSize(): Vector2 {
+        return this._absoluteCanvasSize;
+    }
+    public get AbsoluteWindowSize(): Vector2 {
+        return this._absoluteWindowSize;
+    }
+
+    public get AutomaticCanvasSize(): AutomaticSize {
+        return this._automaticCanvasSize;
+    }
+    public set AutomaticCanvasSize(v: AutomaticSize) {
+        this._automaticCanvasSize = v;
+        this.signalPropertyChanged("AutomaticCanvasSize");
+    }
+
+    public get BottomImage(): string {
+        return this._bottomImage;
+    }
+    public set BottomImage(v: string) {
+        this._bottomImage = v;
+        this.signalPropertyChanged("BottomImage");
+    }
+
+    public get CanvasPosition(): Vector2 {
+        return this._canvasPosition;
+    }
+    public set CanvasPosition(v: Vector2) {
+        this._canvasPosition = v;
+        this.signalPropertyChanged("CanvasPosition");
+    }
+
+    public get CanvasSize(): UDim2 {
+        return this._canvasSize;
+    }
+    public set CanvasSize(v: UDim2) {
+        this._canvasSize = v;
+        this.signalPropertyChanged("CanvasSize");
+    }
+
+    public get ElasticBehavior(): any {
+        return this._elasticBehavior;
+    }
+    public set ElasticBehavior(v: any) {
+        this._elasticBehavior = v;
+        this.signalPropertyChanged("ElasticBehavior");
+    }
+
+    public get HorizontalScrollBarInset(): any {
+        return this._horizontalScrollBarInset;
+    }
+    public set HorizontalScrollBarInset(v: any) {
+        this._horizontalScrollBarInset = v;
+        this.signalPropertyChanged("HorizontalScrollBarInset");
+    }
+
+    public get MidImage(): string {
+        return this._midImage;
+    }
+    public set MidImage(v: string) {
+        this._midImage = v;
+        this.signalPropertyChanged("MidImage");
+    }
+
+    public get ScrollBarImageColor3(): Color3 {
+        return this._scrollBarImageColor3;
+    }
+    public set ScrollBarImageColor3(v: Color3) {
+        this._scrollBarImageColor3 = v;
+        this.signalPropertyChanged("ScrollBarImageColor3");
+    }
+
+    public get ScrollBarImageTransparency(): number {
+        return this._scrollBarImageTransparency;
+    }
+    public set ScrollBarImageTransparency(v: number) {
+        this._scrollBarImageTransparency = v;
+        this.signalPropertyChanged("ScrollBarImageTransparency");
+    }
+
+    public get ScrollBarThickness(): number {
+        return this._scrollBarThickness;
+    }
+    public set ScrollBarThickness(v: number) {
+        this._scrollBarThickness = v;
+        this.signalPropertyChanged("ScrollBarThickness");
+    }
+
+    public get ScrollingDirection(): any {
+        return this._scrollingDirection;
+    }
+    public set ScrollingDirection(v: any) {
+        this._scrollingDirection = v;
+        this.signalPropertyChanged("ScrollingDirection");
+    }
+
+    public get ScrollingEnabled(): boolean {
+        return this._scrollingEnabled;
+    }
+    public set ScrollingEnabled(v: boolean) {
+        this._scrollingEnabled = v;
+        this.signalPropertyChanged("ScrollingEnabled");
+    }
+
+    public get TopImage(): string {
+        return this._topImage;
+    }
+    public set TopImage(v: string) {
+        this._topImage = v;
+        this.signalPropertyChanged("TopImage");
+    }
+
+    public get VerticalScrollBarInset(): any {
+        return this._verticalScrollBarInset;
+    }
+    public set VerticalScrollBarInset(v: any) {
+        this._verticalScrollBarInset = v;
+        this.signalPropertyChanged("VerticalScrollBarInset");
+    }
+
+    public get VerticalScrollBarPosition(): any {
+        return this._verticalScrollBarPosition;
+    }
+    public set VerticalScrollBarPosition(v: any) {
+        this._verticalScrollBarPosition = v;
+        this.signalPropertyChanged("VerticalScrollBarPosition");
+    }
+
+    public Update(dt: number): void {
+        super.Update(dt);
+        this._absoluteWindowSize = this.AbsoluteSize;
+        // naive calculation
+        this._absoluteCanvasSize = {
+            X: this.AbsoluteSize.X,
+            Y: this.AbsoluteSize.Y,
+        };
+    }
+
+    public Draw(): void {
+        if (!this.Visible) return;
+
+        love.graphics.push();
+        love.graphics.translate(
+            this.AbsolutePosition.X + this.AbsoluteSize.X / 2,
+            this.AbsolutePosition.Y + this.AbsoluteSize.Y / 2,
+        );
+        love.graphics.rotate(this.AbsoluteRotation * (Math.PI / 180));
+        love.graphics.translate(-this.AbsoluteSize.X / 2, -this.AbsoluteSize.Y / 2);
+
+        const totalAlpha = 1 - Math.min(1, this.BackgroundTransparency + this.Transparency);
+        const c = this.BackgroundColor3;
+        love.graphics.setColor(c.R, c.G, c.B, totalAlpha);
+        love.graphics.rectangle("fill", 0, 0, this.AbsoluteSize.X, this.AbsoluteSize.Y);
+
+        if (this.BorderSizePixel > 0) {
+            const bc = this.BorderColor3;
+            love.graphics.setColor(bc.R, bc.G, bc.B, totalAlpha);
+            love.graphics.setLineWidth(this.BorderSizePixel);
+            let off = 0;
+            if (this.BorderMode === "Inset") {
+                off = this.BorderSizePixel;
+            } else if (this.BorderMode === "Middle") {
+                off = this.BorderSizePixel / 2;
+            } else {
+                off = 0;
+            }
+            love.graphics.rectangle(
+                "line",
+                -off / 2,
+                -off / 2,
+                this.AbsoluteSize.X + off,
+                this.AbsoluteSize.Y + off,
+            );
+        }
+
+        love.graphics.pop();
+    }
+}

--- a/src/engine/widgets/TextBox.ts
+++ b/src/engine/widgets/TextBox.ts
@@ -1,0 +1,243 @@
+import { Event } from "../core/Event";
+import { AGuiObject } from "./GuiObject";
+
+export class TextBoxWidget extends AGuiObject implements TextBox {
+    private _clearTextOnFocus = true;
+    private _contentText = "";
+    private _cursorPosition = -1;
+    private _font: any = undefined;
+    private _fontFace: any = undefined;
+    private _fontSize: any = undefined;
+    private _lineHeight = 1;
+    private _maxVisibleGraphemes = -1;
+    private _multiLine = false;
+    private _openTypeFeatures = "";
+    private _openTypeFeaturesError = "";
+    private _placeholderColor3: Color3 = { R: 1, G: 1, B: 1 };
+    private _placeholderText = "";
+    private _richText = false;
+    private _selectionStart = -1;
+    private _showNativeInput = false;
+    private _text = "";
+    private _textBounds: Vector2 = { X: 0, Y: 0 };
+    private _textColor3: Color3 = { R: 1, G: 1, B: 1 };
+    private _textDirection: any = undefined;
+    private _textEditable = true;
+    private _textFits = false;
+    private _textScaled = false;
+    private _textSize = 14;
+    private _textStrokeColor3: Color3 = { R: 0, G: 0, B: 0 };
+    private _textStrokeTransparency = 1;
+    private _textTransparency = 0;
+    private _textTruncate: any = undefined;
+    private _textWrap = false;
+    private _textWrapped = false;
+    private _textXAlignment: any = undefined;
+    private _textYAlignment: any = undefined;
+    private _focused = false;
+
+    protected static DefaultProperties = {
+        ...AGuiObject.DefaultProperties,
+        _clearTextOnFocus: true,
+        _contentText: "",
+        _cursorPosition: -1,
+        _font: undefined as any,
+        _fontFace: undefined as any,
+        _fontSize: undefined as any,
+        _lineHeight: 1,
+        _maxVisibleGraphemes: -1,
+        _multiLine: false,
+        _openTypeFeatures: "",
+        _openTypeFeaturesError: "",
+        _placeholderColor3: { R: 1, G: 1, B: 1 },
+        _placeholderText: "",
+        _richText: false,
+        _selectionStart: -1,
+        _showNativeInput: false,
+        _text: "",
+        _textBounds: { X: 0, Y: 0 },
+        _textColor3: { R: 1, G: 1, B: 1 },
+        _textDirection: undefined as any,
+        _textEditable: true,
+        _textFits: false,
+        _textScaled: false,
+        _textSize: 14,
+        _textStrokeColor3: { R: 0, G: 0, B: 0 },
+        _textStrokeTransparency: 1,
+        _textTransparency: 0,
+        _textTruncate: undefined as any,
+        _textWrap: false,
+        _textWrapped: false,
+        _textXAlignment: undefined as any,
+        _textYAlignment: undefined as any,
+    };
+
+    public readonly FocusLost = new Event<{ enterPressed: boolean; inputThatCausedFocusLoss: InputObject }>();
+    public readonly Focused = new Event<void>();
+    public readonly ReturnPressedFromOnScreenKeyboard = new Event<void>();
+
+    public constructor(name: string) {
+        super(name, "TextBox");
+    }
+
+    public get ClearTextOnFocus(): boolean {
+        return this._clearTextOnFocus;
+    }
+    public set ClearTextOnFocus(v: boolean) {
+        this._clearTextOnFocus = v;
+        this.signalPropertyChanged("ClearTextOnFocus");
+    }
+
+    public get ContentText(): string {
+        return this._contentText;
+    }
+
+    public get CursorPosition(): number {
+        return this._cursorPosition;
+    }
+    public set CursorPosition(v: number) {
+        this._cursorPosition = v;
+        this.signalPropertyChanged("CursorPosition");
+    }
+
+    public get Font(): any { return this._font; }
+    public set Font(v: any) { this._font = v; this.signalPropertyChanged("Font"); }
+
+    public get FontFace(): any { return this._fontFace; }
+    public set FontFace(v: any) { this._fontFace = v; this.signalPropertyChanged("FontFace"); }
+
+    public get FontSize(): any { return this._fontSize; }
+    public set FontSize(v: any) { this._fontSize = v; this.signalPropertyChanged("FontSize"); }
+
+    public get LineHeight(): number { return this._lineHeight; }
+    public set LineHeight(v: number) { this._lineHeight = v; this.signalPropertyChanged("LineHeight"); }
+
+    public get MaxVisibleGraphemes(): number { return this._maxVisibleGraphemes; }
+    public set MaxVisibleGraphemes(v: number) { this._maxVisibleGraphemes = v; this.signalPropertyChanged("MaxVisibleGraphemes"); }
+
+    public get MultiLine(): boolean { return this._multiLine; }
+    public set MultiLine(v: boolean) { this._multiLine = v; this.signalPropertyChanged("MultiLine"); }
+
+    public get OpenTypeFeatures(): string { return this._openTypeFeatures; }
+    public set OpenTypeFeatures(v: string) { this._openTypeFeatures = v; this.signalPropertyChanged("OpenTypeFeatures"); }
+
+    public get OpenTypeFeaturesError(): string { return this._openTypeFeaturesError; }
+
+    public get PlaceholderColor3(): Color3 { return this._placeholderColor3; }
+    public set PlaceholderColor3(v: Color3) { this._placeholderColor3 = v; this.signalPropertyChanged("PlaceholderColor3"); }
+
+    public get PlaceholderText(): string { return this._placeholderText; }
+    public set PlaceholderText(v: string) { this._placeholderText = v; this.signalPropertyChanged("PlaceholderText"); }
+
+    public get RichText(): boolean { return this._richText; }
+    public set RichText(v: boolean) { this._richText = v; this.signalPropertyChanged("RichText"); }
+
+    public get SelectionStart(): number { return this._selectionStart; }
+    public set SelectionStart(v: number) { this._selectionStart = v; this.signalPropertyChanged("SelectionStart"); }
+
+    public get ShowNativeInput(): boolean { return this._showNativeInput; }
+    public set ShowNativeInput(v: boolean) { this._showNativeInput = v; this.signalPropertyChanged("ShowNativeInput"); }
+
+    public get Text(): string { return this._text; }
+    public set Text(v: string) { this._text = v; this.signalPropertyChanged("Text"); }
+
+    public get TextBounds(): Vector2 { return this._textBounds; }
+
+    public get TextColor3(): Color3 { return this._textColor3; }
+    public set TextColor3(v: Color3) { this._textColor3 = v; this.signalPropertyChanged("TextColor3"); }
+
+    public get TextDirection(): any { return this._textDirection; }
+    public set TextDirection(v: any) { this._textDirection = v; this.signalPropertyChanged("TextDirection"); }
+
+    public get TextEditable(): boolean { return this._textEditable; }
+    public set TextEditable(v: boolean) { this._textEditable = v; this.signalPropertyChanged("TextEditable"); }
+
+    public get TextFits(): boolean { return this._textFits; }
+
+    public get TextScaled(): boolean { return this._textScaled; }
+    public set TextScaled(v: boolean) { this._textScaled = v; this.signalPropertyChanged("TextScaled"); }
+
+    public get TextSize(): number { return this._textSize; }
+    public set TextSize(v: number) { this._textSize = v; this.signalPropertyChanged("TextSize"); }
+
+    public get TextStrokeColor3(): Color3 { return this._textStrokeColor3; }
+    public set TextStrokeColor3(v: Color3) { this._textStrokeColor3 = v; this.signalPropertyChanged("TextStrokeColor3"); }
+
+    public get TextStrokeTransparency(): number { return this._textStrokeTransparency; }
+    public set TextStrokeTransparency(v: number) { this._textStrokeTransparency = v; this.signalPropertyChanged("TextStrokeTransparency"); }
+
+    public get TextTransparency(): number { return this._textTransparency; }
+    public set TextTransparency(v: number) { this._textTransparency = v; this.signalPropertyChanged("TextTransparency"); }
+
+    public get TextTruncate(): any { return this._textTruncate; }
+    public set TextTruncate(v: any) { this._textTruncate = v; this.signalPropertyChanged("TextTruncate"); }
+
+    public get TextWrap(): boolean { return this._textWrap; }
+    public set TextWrap(v: boolean) { this._textWrap = v; this.signalPropertyChanged("TextWrap"); }
+
+    public get TextWrapped(): boolean { return this._textWrapped; }
+    public set TextWrapped(v: boolean) { this._textWrapped = v; this.signalPropertyChanged("TextWrapped"); }
+
+    public get TextXAlignment(): any { return this._textXAlignment; }
+    public set TextXAlignment(v: any) { this._textXAlignment = v; this.signalPropertyChanged("TextXAlignment"); }
+
+    public get TextYAlignment(): any { return this._textYAlignment; }
+    public set TextYAlignment(v: any) { this._textYAlignment = v; this.signalPropertyChanged("TextYAlignment"); }
+
+    public CaptureFocus(): void {
+        this._focused = true;
+        this.Focused.Fire(undefined);
+    }
+
+    public IsFocused(): boolean {
+        return this._focused;
+    }
+
+    public ReleaseFocus(submitted = false): void {
+        this._focused = false;
+        this.FocusLost.Fire({ enterPressed: submitted, inputThatCausedFocusLoss: {} as InputObject });
+    }
+
+    public Draw(): void {
+        if (!this.Visible) return;
+
+        love.graphics.push();
+        love.graphics.translate(
+            this.AbsolutePosition.X + this.AbsoluteSize.X / 2,
+            this.AbsolutePosition.Y + this.AbsoluteSize.Y / 2,
+        );
+        love.graphics.rotate(this.AbsoluteRotation * (Math.PI / 180));
+        love.graphics.translate(-this.AbsoluteSize.X / 2, -this.AbsoluteSize.Y / 2);
+
+        const totalAlpha = 1 - Math.min(1, this.BackgroundTransparency + this.Transparency);
+        const c = this.BackgroundColor3;
+        love.graphics.setColor(c.R, c.G, c.B, totalAlpha);
+        love.graphics.rectangle("fill", 0, 0, this.AbsoluteSize.X, this.AbsoluteSize.Y);
+
+        if (this.BorderSizePixel > 0) {
+            const bc = this.BorderColor3;
+            love.graphics.setColor(bc.R, bc.G, bc.B, totalAlpha);
+            love.graphics.setLineWidth(this.BorderSizePixel);
+            let off = 0;
+            if (this.BorderMode === "Inset") {
+                off = this.BorderSizePixel;
+            } else if (this.BorderMode === "Middle") {
+                off = this.BorderSizePixel / 2;
+            } else {
+                off = 0;
+            }
+            love.graphics.rectangle(
+                "line",
+                -off / 2,
+                -off / 2,
+                this.AbsoluteSize.X + off,
+                this.AbsoluteSize.Y + off,
+            );
+        }
+
+        love.graphics.setColor(this._textColor3.R, this._textColor3.G, this._textColor3.B, 1 - this._textTransparency);
+        love.graphics.print(this._text, 2, 2);
+
+        love.graphics.pop();
+    }
+}

--- a/src/engine/widgets/types.d.ts
+++ b/src/engine/widgets/types.d.ts
@@ -50,6 +50,11 @@ interface InputObject {}
 interface Instances {
         Frame: Frame;
         RootWidget: Frame;
+        CanvasGroup: CanvasGroup;
+        GuiButton: GuiButton;
+        GuiLabel: GuiLabel;
+        ScrollingFrame: ScrollingFrame;
+        TextBox: TextBox;
 }
 
 interface Instance {
@@ -530,3 +535,86 @@ interface GuiObject extends GuiBase {
 
 interface Frame extends GuiObject {}
 interface RootWidget extends Frame {}
+
+interface CanvasGroup extends GuiObject {
+    GroupColor3: Color3;
+    GroupTransparency: number;
+}
+
+interface GuiButton extends GuiObject {
+    AutoButtonColor: boolean;
+    Modal: boolean;
+    Selected: boolean;
+    Style: any;
+    readonly Activated: IEvent<(inputObject: InputObject, clickCount: number) => void>;
+    readonly MouseButton1Click: IEvent<() => void>;
+    readonly MouseButton1Down: IEvent<(x: number, y: number) => void>;
+    readonly MouseButton1Up: IEvent<(x: number, y: number) => void>;
+    readonly MouseButton2Click: IEvent<() => void>;
+    readonly MouseButton2Down: IEvent<(x: number, y: number) => void>;
+    readonly MouseButton2Up: IEvent<(x: number, y: number) => void>;
+}
+
+interface GuiLabel extends GuiObject {
+}
+
+interface ScrollingFrame extends GuiObject {
+    readonly AbsoluteCanvasSize: Vector2;
+    readonly AbsoluteWindowSize: Vector2;
+    AutomaticCanvasSize: AutomaticSize;
+    BottomImage: string;
+    CanvasPosition: Vector2;
+    CanvasSize: UDim2;
+    ElasticBehavior: any;
+    HorizontalScrollBarInset: any;
+    MidImage: string;
+    ScrollBarImageColor3: Color3;
+    ScrollBarImageTransparency: number;
+    ScrollBarThickness: number;
+    ScrollingDirection: any;
+    ScrollingEnabled: boolean;
+    TopImage: string;
+    VerticalScrollBarInset: any;
+    VerticalScrollBarPosition: any;
+}
+
+interface TextBox extends GuiObject {
+    ClearTextOnFocus: boolean;
+    readonly ContentText: string;
+    CursorPosition: number;
+    Font: any;
+    FontFace: any;
+    FontSize: any;
+    LineHeight: number;
+    MaxVisibleGraphemes: number;
+    MultiLine: boolean;
+    OpenTypeFeatures: string;
+    readonly OpenTypeFeaturesError: string;
+    PlaceholderColor3: Color3;
+    PlaceholderText: string;
+    RichText: boolean;
+    SelectionStart: number;
+    ShowNativeInput: boolean;
+    Text: string;
+    readonly TextBounds: Vector2;
+    TextColor3: Color3;
+    TextDirection: any;
+    TextEditable: boolean;
+    readonly TextFits: boolean;
+    TextScaled: boolean;
+    TextSize: number;
+    TextStrokeColor3: Color3;
+    TextStrokeTransparency: number;
+    TextTransparency: number;
+    TextTruncate: any;
+    TextWrap: boolean;
+    TextWrapped: boolean;
+    TextXAlignment: any;
+    TextYAlignment: any;
+    CaptureFocus(this: TextBox): void;
+    IsFocused(this: TextBox): boolean;
+    ReleaseFocus(this: TextBox, submitted?: boolean): void;
+    readonly FocusLost: IEvent<{ enterPressed: boolean; inputThatCausedFocusLoss: InputObject }>;
+    readonly Focused: IEvent<void>;
+    readonly ReturnPressedFromOnScreenKeyboard: IEvent<void>;
+}


### PR DESCRIPTION
## Summary
- implement widget classes CanvasGroupWidget, GuiButtonWidget, GuiLabelWidget, ScrollingFrameWidget and TextBoxWidget
- register new widgets in `InstanceManager`
- extend public type declarations with new widget interfaces

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686724f055b0832e89a19e091b1be5fb